### PR TITLE
backend: add response object in health check endpoint

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -33,13 +33,24 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.junit.vintage</groupId>
+					<artifactId>junit-vintage-engine</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
-		
 		<dependency>
 		    <groupId>com.h2database</groupId>
 		    <artifactId>h2</artifactId>
 		    <version>1.4.200</version>
 		    <scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest-library</artifactId>
+			<version>2.2</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/backend/src/main/java/com/fortunator/api/controller/HealthController.java
+++ b/backend/src/main/java/com/fortunator/api/controller/HealthController.java
@@ -1,6 +1,10 @@
 package com.fortunator.api.controller;
 
+import java.util.Map;
+import java.util.HashMap;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -10,8 +14,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class HealthController {
 	
 	@GetMapping
-	public ResponseEntity test(){
-		return ResponseEntity.ok().build();
+	public ResponseEntity<Map<String, String>> healthCheck(){
+		Map<String, String> response = new HashMap<>();
+		response.put("status", "Up and kicking");
+
+		return new ResponseEntity<>(response, HttpStatus.OK);
 	}
 	
 	

--- a/backend/src/test/java/com/fortunator/api/controller/HealthControllerTest.java
+++ b/backend/src/test/java/com/fortunator/api/controller/HealthControllerTest.java
@@ -1,0 +1,24 @@
+package com.fortunator.api.controller;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+@WebMvcTest
+public class HealthControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	public void shouldReturnStatusCodeOk() throws Exception {
+		this.mockMvc.perform(get("/health"))
+		.andExpect(status().isOk())
+		.andExpect(jsonPath("$.status", is("Up and kicking")));
+	}
+}


### PR DESCRIPTION
# Descrição

Esse PR simplesmente adiciona um objeto de resposta no endpoint `/health` da API, para que possamos ver visualmente que a API está funcionando além do status code 200.

Resolves #17