### PR TITLE
front: pass api url as env variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - "3000:3000"
     environment:  
       - CHOKIDAR_USEPOLLING=true
+      - REACT_APP_API_URL=http://localhost:8080
     stdin_open: true
 
   postgres:

--- a/frontend/src/service/api.js
+++ b/frontend/src/service/api.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const api = axios.create({
-    baseURL: 'http://localhost:8080'
+    baseURL: process.env.REACT_APP_API_URL || 'http://localhost:8080'
 })
 
 export default api;


### PR DESCRIPTION
# Descrição

Esse PR faz com que a url da API no front seja passada através de variável de ambiente. 

Resolves #38 