### PR TITLE
Add tests for registering and login users

### DIFF
--- a/backend/src/main/java/com/fortunator/api/models/User.java
+++ b/backend/src/main/java/com/fortunator/api/models/User.java
@@ -74,4 +74,30 @@ public class User {
 	public void setPassword(String password) {
 		this.password = password;
 	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+
+		User other = (User) obj;
+
+		if (email == null) {
+			if (other.email != null)
+				return false;
+		} else if (!email.equals(other.email))
+			return false;
+
+		if (id == null) {
+			if (other.id != null)
+				return false;
+		} else if (!id.equals(other.id))
+			return false;
+
+		return true;
+	}
 }

--- a/backend/src/main/java/com/fortunator/api/service/UserService.java
+++ b/backend/src/main/java/com/fortunator/api/service/UserService.java
@@ -20,7 +20,7 @@ public class UserService {
 	
 	public User registerUser(User user) {
 		if(findByEmail(user.getEmail()).isPresent()) {
-			throw new EmailExistsException("Email alredy registered, please enter another email and try again.");
+			throw new EmailExistsException("Email already registered, please enter another email and try again.");
 		}
 		user.setPassword(String.valueOf(user.getPassword().hashCode()));
 		return userRepository.save(user);

--- a/backend/src/test/java/com/fortunator/api/controller/HealthControllerTest.java
+++ b/backend/src/test/java/com/fortunator/api/controller/HealthControllerTest.java
@@ -1,4 +1,5 @@
 package com.fortunator.api.controller;
+
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;

--- a/backend/src/test/java/com/fortunator/api/controller/UserControllerTest.java
+++ b/backend/src/test/java/com/fortunator/api/controller/UserControllerTest.java
@@ -1,0 +1,52 @@
+package com.fortunator.api.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.junit.jupiter.api.Test;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+
+import com.fortunator.api.models.User;
+import com.fortunator.api.service.*;
+
+@WebMvcTest(UserController.class)
+public class UserControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockBean
+	private UserService service;
+
+	@Test
+	public void shouldCreateUserSuccessfully() throws Exception {
+
+		this.mockMvc
+				.perform(post("/users").contentType(MediaType.APPLICATION_JSON).content(
+						asJsonString(new User(null, "kaique", "kaique@boladao.com", "senhadokaique123"))))
+				.andExpect(status().isCreated());
+	}
+
+	@Test
+	public void shouldNotCreateDueToInvalidEmail() throws Exception {
+
+		this.mockMvc
+				.perform(post("/users").contentType(MediaType.APPLICATION_JSON)
+						.content(asJsonString(new User(null, "kaique", "email", "senhadokaique123"))))
+				.andExpect(status().isBadRequest());
+	}
+
+	public static String asJsonString(final Object obj) {
+		try {
+			return new ObjectMapper().writeValueAsString(obj);
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/backend/src/test/java/com/fortunator/api/service/UserServiceTest.java
+++ b/backend/src/test/java/com/fortunator/api/service/UserServiceTest.java
@@ -1,0 +1,78 @@
+package com.fortunator.api.service;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ContextConfiguration;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+import javax.security.auth.login.LoginException;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+import com.fortunator.api.models.User;
+import com.fortunator.api.repository.UserRepository;
+import com.fortunator.api.service.exceptions.*;
+
+@ContextConfiguration(classes = { UserService.class })
+@ExtendWith(MockitoExtension.class)
+public class UserServiceTest {
+	@Mock
+	private UserRepository userRepository;
+
+	@InjectMocks
+	private UserService userService;
+
+	@Test
+	public void shouldRegisterEmailSuccessfully() throws Exception {
+		final User user = new User(null, "roger", "roger@email.com", "senhadoroger");
+
+		doReturn(Optional.empty()).when(userRepository).findByEmail("roger@email.com");
+		doReturn(user).when(userRepository).save(user);
+
+		User savedUser = userService.registerUser(user);
+
+		assertTrue(savedUser.equals(user));
+	}
+
+	@Test
+	public void shouldNotRegisterSameEmailTwice() throws Exception {
+		final User user = new User(null, "roger", "roger@email.com", "senhadoroger");
+
+		doReturn(Optional.of(user)).when(userRepository).findByEmail("roger@email.com");
+
+		EmailExistsException thrown = assertThrows(EmailExistsException.class, () -> userService.registerUser(user));
+
+		assertTrue(thrown.getMessage().contains("Email already registered"));
+	}
+
+	@Test
+	public void shouldNotLoginIfNotRegistered() throws Exception {
+		String email = "joao@email.com";
+		String password = "senhadojoao";
+
+		doReturn(Optional.empty()).when(userRepository).findByEmail("joao@email.com");
+
+		UserNotFoundException thrown = assertThrows(UserNotFoundException.class, () -> userService.doLogin(email, password));
+
+		assertTrue(thrown.getMessage().contains("Email not registered for any user"));
+	}
+
+	@Test
+	public void shouldNotLoginWhenIncorrectPassword() throws Exception {
+		String email = "joao@email.com";
+		String password = "errou!";
+
+		final User user = new User(null, "joao", email, "senhadojoao");
+
+		doReturn(Optional.of(user)).when(userRepository).findByEmail("joao@email.com");
+
+		LoginException thrown = assertThrows(LoginException.class, () -> userService.doLogin(email, password));
+
+		assertTrue(thrown.getMessage().contains("Password is incorrect."));
+	}
+	
+}


### PR DESCRIPTION
# Descrição

Esse PR adiciona testes para o fluxo de criação de usuários e login, que ficou faltando na sprint passada e acabou virando um débito técnico para a sprint atual.

Nele contém:
- Testes para camada controller
- Teste para camada service


resolves #71 