### PR TITLE
Add default transaction categories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: default all build down test
+.PHONY: default all build down test backend database
 
 default: all
 
@@ -13,3 +13,9 @@ down:
 
 test:
 	@docker-compose up test-backend
+
+backend:
+	@docker-compose up backend
+
+database:
+	@docker-compose up -d postgres

--- a/backend/src/main/java/com/fortunator/api/models/TransactionCategory.java
+++ b/backend/src/main/java/com/fortunator/api/models/TransactionCategory.java
@@ -27,6 +27,8 @@ public class TransactionCategory {
 	@ManyToOne
 	private User user;
 	
+	private boolean isDefault;
+	
 	public TransactionCategory() {
 	}
 
@@ -35,6 +37,15 @@ public class TransactionCategory {
 		this.name = name;
 		this.description = description;
 		this.user = user;
+		this.isDefault = false;
+	}
+
+	public TransactionCategory(Long id, String name, String description, User user, Boolean isDefault) {
+		this.id = id;
+		this.name = name;
+		this.description = description;
+		this.user = user;
+		this.isDefault = isDefault;
 	}
 
 	public Long getId() {
@@ -67,5 +78,13 @@ public class TransactionCategory {
 
 	public void setUser(User user) {
 		this.user = user;
+	}
+
+	public boolean getIsDefault() {
+		return isDefault;
+	}
+
+	public void setIsDefault(Boolean isDefault) {
+		this.isDefault = isDefault;
 	}
 }

--- a/backend/src/main/java/com/fortunator/api/models/TransactionCategory.java
+++ b/backend/src/main/java/com/fortunator/api/models/TransactionCategory.java
@@ -12,23 +12,23 @@ import javax.validation.constraints.Size;
 @Entity
 @Table(name = "transaction_categories")
 public class TransactionCategory {
-	
+
 	@Id
-	@GeneratedValue(strategy=GenerationType.IDENTITY)
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
-	
+
 	@NotBlank
 	@Size(max = 60)
 	private String name;
-	
+
 	@Size(max = 255)
 	private String description;
-	
+
 	@ManyToOne
 	private User user;
-	
+
 	private boolean isDefault;
-	
+
 	public TransactionCategory() {
 	}
 
@@ -80,11 +80,41 @@ public class TransactionCategory {
 		this.user = user;
 	}
 
-	public boolean getIsDefault() {
+	public boolean isDefault() {
 		return isDefault;
 	}
 
 	public void setIsDefault(Boolean isDefault) {
 		this.isDefault = isDefault;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+
+		if (obj == null)
+			return false;
+
+		if (getClass() != obj.getClass())
+			return false;
+
+		TransactionCategory other = (TransactionCategory) obj;
+
+		if (id == null) {
+			if (other.id != null)
+				return false;
+
+		} else if (!id.equals(other.id))
+			return false;
+
+		if (name == null) {
+			if (other.name != null)
+				return false;
+
+		} else if (!name.equals(other.name))
+			return false;
+
+		return true;
 	}
 }

--- a/backend/src/main/java/com/fortunator/api/models/User.java
+++ b/backend/src/main/java/com/fortunator/api/models/User.java
@@ -15,24 +15,24 @@ import com.fasterxml.jackson.annotation.JsonProperty.Access;
 @Entity
 @Table(name = "users")
 public class User {
-	
+
 	@Id
-	@GeneratedValue(strategy=GenerationType.IDENTITY)
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
-	
+
 	@NotBlank
 	@Size(max = 60)
 	private String name;
-	
+
 	@NotBlank
 	@Email
 	@Size(max = 255)
 	private String email;
-	
+
 	@NotBlank
 	@Size(max = 32)
 	private String password;
-	
+
 	public User() {
 	}
 

--- a/backend/src/main/java/com/fortunator/api/repository/TransactionCategoryRepository.java
+++ b/backend/src/main/java/com/fortunator/api/repository/TransactionCategoryRepository.java
@@ -11,4 +11,5 @@ import com.fortunator.api.models.TransactionCategory;
 public interface TransactionCategoryRepository extends JpaRepository<TransactionCategory, Long>{
 
 	List<TransactionCategory> findByUserId(Long userId);
+	List<TransactionCategory> findByIsDefault(Boolean isDefault);
 }

--- a/backend/src/main/java/com/fortunator/api/service/TransactionCategoryService.java
+++ b/backend/src/main/java/com/fortunator/api/service/TransactionCategoryService.java
@@ -13,23 +13,29 @@ import com.fortunator.api.service.exceptions.UserNotFoundException;
 
 @Service
 public class TransactionCategoryService {
-	
+
 	@Autowired
-	private TransactionCategoryRepository transactionCategoryRepository;	
-	
+	private TransactionCategoryRepository transactionCategoryRepository;
+
 	@Autowired
 	private UserRepository userRepository;
-	
+
 	public TransactionCategory createCategory(TransactionCategory transactionCategory) {
 		User user = userRepository.findById(transactionCategory.getUser().getId())
 				.orElseThrow(() -> new UserNotFoundException("User does not exist"));
-		
+
 		transactionCategory.setUser(user);
 		transactionCategory.setName(transactionCategory.getName().replaceAll(" ", "_").toLowerCase());
 		return transactionCategoryRepository.save(transactionCategory);
 	}
-	
+
 	public List<TransactionCategory> getCategoriesByUserId(Long userId) {
-		return transactionCategoryRepository.findByUserId(userId);
+		List<TransactionCategory> defaultCategories = transactionCategoryRepository.findByIsDefault(true);
+		List<TransactionCategory> userCategories = transactionCategoryRepository.findByUserId(userId);
+
+		defaultCategories.addAll(userCategories);
+
+		return defaultCategories;
+
 	}
 }

--- a/backend/src/main/resources/db/migration/V003__insert-transaction-categories.sql
+++ b/backend/src/main/resources/db/migration/V003__insert-transaction-categories.sql
@@ -1,0 +1,11 @@
+ALTER TABLE transaction_categories ALTER COLUMN user_id drop not NULL;
+
+ALTER TABLE transaction_categories ADD COLUMN is_default boolean NOT NULL DEFAULT false;
+
+INSERT INTO transaction_categories (name, description, is_default) VALUES
+    ('comida', 'Comida', true),
+    ('transporte', 'Transporte', true),
+    ('lazer', 'Lazer', true),
+    ('educacao', 'Educação', true),
+    ('outros', 'Outros', true),
+    ('saude', 'Saúde', true);

--- a/backend/src/test/java/com/fortunator/api/service/TransactionCategoryTest.java
+++ b/backend/src/test/java/com/fortunator/api/service/TransactionCategoryTest.java
@@ -2,6 +2,8 @@ package com.fortunator.api.service;
 
 import java.util.Optional;
 import java.util.List;
+import java.util.ArrayList;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfiguration;
 import org.mockito.InjectMocks;
@@ -65,13 +67,16 @@ public class TransactionCategoryTest {
 
     @Test
     public void shouldReturnCategoriesByUser() throws Exception {
-        long userId = 10;
+        Long userId = 10L;
         
         final User user = new User(userId, "roger", "roger@email.com", "senhadoroger");
-        final TransactionCategory category = new TransactionCategory(null, "delivery",
+        
+        final TransactionCategory category = new TransactionCategory(10L, "delivery",
                 "Aquelas comidinhas que peço de noite né", user);
 
-        doReturn(List.of(category)).when(transactionCategoryRepository).findByUserId(userId);
+
+        doReturn(new ArrayList<TransactionCategory>(List.of(category))).when(transactionCategoryRepository).findByUserId(userId);
+        doReturn(new ArrayList<TransactionCategory>(List.of(category))).when(transactionCategoryRepository).findByIsDefault(true);
 
         List<TransactionCategory> categories = transactionCategoryService.getCategoriesByUserId(userId);
 


### PR DESCRIPTION
# Descrição

Esse PR adiciona categorias de transações padrões que a aplicação irá oferecer ao usuário. Esses dados serão inseridos no banco através de migrations.

Além disso, foi adicionado uma lógica na rota GET `transactions/categories/:user_id` para que retorne também essas categorias padrões junto com as categorias que o usuário já criou.

Resolves #81 