### PR TITLE
Backend delete category

### DIFF
--- a/backend/src/main/java/com/fortunator/api/config/DevConfig.java
+++ b/backend/src/main/java/com/fortunator/api/config/DevConfig.java
@@ -79,12 +79,14 @@ public class DevConfig implements CommandLineRunner {
 		transactionCategorySalary.setUser(user);
 		transactionCategorySalary.setName("salary");
 		transactionCategorySalary.setDescription("salary");
+		transactionCategorySalary.setActive(true);
 
 		TransactionCategory transactionCategoryFastFood = new TransactionCategory();
 		transactionCategoryFastFood.setUser(user);
 		transactionCategoryFastFood.setName("fast_food");
 		transactionCategoryFastFood.setDescription("Fast food");
-
+		transactionCategoryFastFood.setActive(true);
+		
 		transactionCategoryRepository.save(transactionCategorySalary);
 		transactionCategoryRepository.save(transactionCategoryFastFood);
 

--- a/backend/src/main/java/com/fortunator/api/controller/TransactionCategoryController.java
+++ b/backend/src/main/java/com/fortunator/api/controller/TransactionCategoryController.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -51,6 +52,28 @@ public class TransactionCategoryController {
 	@GetMapping("/{userId}")
 	public ResponseEntity<List<TransactionCategory>> getCategoriesByUser(@PathVariable Long userId) {
 		List<TransactionCategory> categories = transactionCategoryService.getCategoriesByUserId(userId);
+		if(categories.isEmpty()) {
+			return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+		}
+		return new ResponseEntity<List<TransactionCategory>>(categories, HttpStatus.OK);
+	}
+	
+	@CrossOrigin
+	@ApiOperation(value = "Delete a category")
+	@ApiResponses(value = { @ApiResponse(code = SC_OK, message = "ok")})
+	@DeleteMapping("/{categoryId}")
+	public ResponseEntity<Void> deleteCategory(@PathVariable Long categoryId) {
+		transactionCategoryService.disableCategory(categoryId);
+		return ResponseEntity.ok().build(); 
+	}
+	
+	@CrossOrigin
+	@ApiOperation(value = "Get created categories")
+	@ApiResponses(value = { @ApiResponse(code = SC_OK, message = "ok"),
+			@ApiResponse(code = NO_CONTENT, message = "When has no categories.") })
+	@GetMapping("/created/{userId}")
+	public ResponseEntity<List<TransactionCategory>> getCreatedCategories(@PathVariable Long userId) {
+		List<TransactionCategory> categories = transactionCategoryService.getCreatedCategories(userId);
 		if(categories.isEmpty()) {
 			return new ResponseEntity<>(HttpStatus.NO_CONTENT);
 		}

--- a/backend/src/main/java/com/fortunator/api/models/TransactionCategory.java
+++ b/backend/src/main/java/com/fortunator/api/models/TransactionCategory.java
@@ -32,6 +32,8 @@ public class TransactionCategory {
 	private User user;
 
 	private boolean isDefault;
+	
+	private boolean active;
 
 	public TransactionCategory() {
 	}
@@ -90,6 +92,14 @@ public class TransactionCategory {
 
 	public void setIsDefault(Boolean isDefault) {
 		this.isDefault = isDefault;
+	}
+	
+	public boolean isActive() {
+		return active;
+	}
+	
+	public void setActive(boolean active) {
+		this.active = active;
 	}
 
 	@Override

--- a/backend/src/main/java/com/fortunator/api/service/TransactionCategoryService.java
+++ b/backend/src/main/java/com/fortunator/api/service/TransactionCategoryService.java
@@ -2,6 +2,7 @@ package com.fortunator.api.service;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -10,10 +11,13 @@ import com.fortunator.api.models.TransactionCategory;
 import com.fortunator.api.models.User;
 import com.fortunator.api.repository.TransactionCategoryRepository;
 import com.fortunator.api.repository.UserRepository;
+import com.fortunator.api.service.exceptions.ResourceNotFoundException;
 import com.fortunator.api.service.exceptions.UserNotFoundException;
 
 @Service
 public class TransactionCategoryService {
+	
+	private static final boolean DISABLE = false;
 
 	@Autowired
 	private TransactionCategoryRepository transactionCategoryRepository;
@@ -32,7 +36,7 @@ public class TransactionCategoryService {
 
 	public List<TransactionCategory> getCategoriesByUserId(Long userId) {
 		List<TransactionCategory> defaultCategories = transactionCategoryRepository.findByIsDefault(true);
-		List<TransactionCategory> userCategories = transactionCategoryRepository.findByUserId(userId);
+		List<TransactionCategory> userCategories = filterActiveCategories(transactionCategoryRepository.findByUserId(userId));
 
 		defaultCategories.addAll(userCategories);
 
@@ -40,7 +44,24 @@ public class TransactionCategoryService {
 
 	}
 	
-	public Optional<TransactionCategory> findById(Long transactionCategoryId){
+	public List<TransactionCategory> getCreatedCategories(Long userId){
+		return filterActiveCategories(transactionCategoryRepository.findByUserId(userId));
+	}
+
+	private List<TransactionCategory> filterActiveCategories(List<TransactionCategory> categories) {
+		return categories.stream().filter(category -> category.isActive()).collect(Collectors.toList());
+	}
+
+	public Optional<TransactionCategory> findById(Long transactionCategoryId) {
 		return transactionCategoryRepository.findById(transactionCategoryId);
+	}
+
+	public void disableCategory(Long categoryId) {
+		TransactionCategory category = transactionCategoryRepository.findById(categoryId)
+				.orElseThrow(() -> new ResourceNotFoundException("Category not found"));
+		
+		category.setActive(DISABLE);
+		
+		transactionCategoryRepository.save(category);
 	}
 }

--- a/backend/src/main/resources/db/migration/V012__alter-add-column-active-in-category.sql
+++ b/backend/src/main/resources/db/migration/V012__alter-add-column-active-in-category.sql
@@ -1,0 +1,1 @@
+alter table transaction_categories add active boolean default true NOT NULL;

--- a/backend/src/test/java/com/fortunator/api/controller/TransactionCategoryControllerTest.java
+++ b/backend/src/test/java/com/fortunator/api/controller/TransactionCategoryControllerTest.java
@@ -15,8 +15,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fortunator.api.models.TransactionCategory;
 import com.fortunator.api.service.*;
 
-	@WebMvcTest(TransactionCategoryController.class)
-public class TransactionCategoryTest {
+@WebMvcTest(TransactionCategoryController.class)
+public class TransactionCategoryControllerTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/backend/src/test/java/com/fortunator/api/service/TransactionCategoryServiceTest.java
+++ b/backend/src/test/java/com/fortunator/api/service/TransactionCategoryServiceTest.java
@@ -1,35 +1,48 @@
 package com.fortunator.api.service;
 
-import java.util.Optional;
-import java.util.List;
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.test.context.ContextConfiguration;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.ContextConfiguration;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.*;
-
-import com.fortunator.api.models.User;
 import com.fortunator.api.models.TransactionCategory;
-import com.fortunator.api.repository.UserRepository;
+import com.fortunator.api.models.User;
 import com.fortunator.api.repository.TransactionCategoryRepository;
-
-import com.fortunator.api.service.exceptions.*;
+import com.fortunator.api.repository.UserRepository;
+import com.fortunator.api.service.exceptions.UserNotFoundException;
 
 @ContextConfiguration(classes = { TransactionCategoryService.class })
 @ExtendWith(MockitoExtension.class)
 public class TransactionCategoryServiceTest {
+	
+	private static final Long USER_ID = 1L;
+	private static final Long CATEGORY_ID = 1L;
+	private static final int LIST_SIZE = 1;
+	private static final boolean ACTIVE = true;
+	private static final boolean DISABLED = false;
+	
     @Mock
     private UserRepository userRepository;
 
     @Mock
     private TransactionCategoryRepository transactionCategoryRepository;
+    
+    @Mock
+    private TransactionCategory category;
 
     @InjectMocks
     private TransactionCategoryService transactionCategoryService;
@@ -81,6 +94,35 @@ public class TransactionCategoryServiceTest {
         List<TransactionCategory> categories = transactionCategoryService.getCategoriesByUserId(userId);
 
         assertTrue(categories.contains(category));
+    }
+    
+    @Test
+    public void shouldReturnListTransactions() {
+    	when(transactionCategoryRepository.findByUserId(eq(USER_ID))).thenReturn(asList(category));
+    	when(category.isActive()).thenReturn(ACTIVE);
+    	
+    	List<TransactionCategory> methodResult = transactionCategoryService.getCreatedCategories(USER_ID);
+    	
+    	assertTrue(methodResult.size() == LIST_SIZE);
+    }
+    
+    @Test
+    public void givenIsDisabledCategoryThenShouldReturnEmptyList() {
+    	when(transactionCategoryRepository.findByUserId(eq(USER_ID))).thenReturn(asList(category));
+    	when(category.isActive()).thenReturn(DISABLED);
+    	
+    	List<TransactionCategory> methodResult = transactionCategoryService.getCreatedCategories(USER_ID);
+    	
+    	assertTrue(methodResult.isEmpty());
+    }
+    
+    @Test
+    public void shouldDisableCategory() {
+    	when(transactionCategoryRepository.findById(CATEGORY_ID)).thenReturn(Optional.of(category));
+    	
+    	transactionCategoryService.disableCategory(CATEGORY_ID);
+    
+    	verify(category).setActive(eq(DISABLED));
     }
 
 }


### PR DESCRIPTION
## Descrição

Esse PR cria um enpoint para deletar uma categoria, cria um outro para pegar apenas as categorias criadas e atualiza o endpoint existente para trazer apenas categorias ativas.

 Resolves #109 